### PR TITLE
Added attribute splatting to SortableList

### DIFF
--- a/BlazorSortableList.Lib/SortableList.razor
+++ b/BlazorSortableList.Lib/SortableList.razor
@@ -6,7 +6,7 @@
 
 @typeparam T
 
-<div id="@Id" style ="@Style">
+<div id="@Id" style ="@Style" @attributes="Attributes">
     @if (Items != null)
     {
         @foreach (var item in Items)

--- a/BlazorSortableList.Lib/SortableList.razor.cs
+++ b/BlazorSortableList.Lib/SortableList.razor.cs
@@ -64,6 +64,9 @@ namespace BlazorSortableList
         public bool Sort { get; set; } = true;
         [Parameter]
         public string? Style { get; set; }
+        
+        [Parameter(CaptureUnmatchedValues = true)]
+        public IDictionary<string, object>? Attributes { get; set; }
 
         [Parameter]
         public RenderFragment<T>? SortableItemTemplate { get; set; }


### PR DESCRIPTION
I lacked the ability to provide classes to the parent div, so I've added this attribute splatting mechanic to the component. This allows any attribute to be passed along, not only the class attribute.

See also: https://learn.microsoft.com/en-us/aspnet/core/blazor/components/splat-attributes-and-arbitrary-parameters?view=aspnetcore-9.0