### PR TITLE
Re-introduce .NET8 support

### DIFF
--- a/BlazorSortableList.Lib/BlazorSortableList.csproj
+++ b/BlazorSortableList.Lib/BlazorSortableList.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackageReadmeFile>README.MD</PackageReadmeFile>
@@ -32,8 +32,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components">
+      <Version Condition="'$(TargetFramework)' == 'net8.0'">8.0.11</Version>
+      <Version Condition="'$(TargetFramework)' == 'net9.0'">9.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web">
+      <Version Condition="'$(TargetFramework)' == 'net8.0'">8.0.11</Version>
+      <Version Condition="'$(TargetFramework)' == 'net9.0'">9.0.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Update="SortableList.razor">


### PR DESCRIPTION
Nuget package 2.1.0 still targetted .NET 8, but this was dropped in development following the .NET 9 upgrade.

I've re-introduced .NET 8 targetting using conditional package references, so that now both .NET 8 and .NET 9 are targetted.

It would seem everything still works, but probably you'll be the better judge of that.