### PR TITLE
Destroy the Sortable instance when the component is disposed

### DIFF
--- a/BlazorSortableList.Lib/SortableList.razor
+++ b/BlazorSortableList.Lib/SortableList.razor
@@ -4,6 +4,8 @@
 
 @inject IJSRuntime JS
 
+@implements IAsyncDisposable
+
 @typeparam T
 
 <div id="@Id" style ="@Style">

--- a/BlazorSortableList.Lib/SortableList.razor.cs
+++ b/BlazorSortableList.Lib/SortableList.razor.cs
@@ -15,6 +15,12 @@ namespace BlazorSortableList
 
         private IJSObjectReference? _module;
 
+        /// <summary>
+        /// The id the JS instance was registered under. <see cref="Id"/> is a mutable parameter, so it
+        /// cannot be trusted to still hold the key the instance is stored against by disposal time.
+        /// </summary>
+        private string? _initializedId;
+
         private string _cssForSelection;
 
         private string? _multiDragKey = string.Empty;
@@ -72,23 +78,37 @@ namespace BlazorSortableList
 
         public async ValueTask DisposeAsync()
         {
-            if (_module != null)
+            try
             {
-                try
+                if (_module != null)
                 {
-                    await _module.InvokeVoidAsync("destroy", Id);
-                    await _module.DisposeAsync();
+                    try
+                    {
+                        if (_initializedId != null)
+                        {
+                            await _module.InvokeVoidAsync("destroy", _initializedId);
+                        }
+                    }
+                    finally
+                    {
+                        await _module.DisposeAsync();
+                    }
                 }
-                catch (JSDisconnectedException)
-                {
-                    // The circuit is already gone, so there is nothing left to clean up on the JS side.
-                }
-
-                _module = null;
             }
-
-            selfReference?.Dispose();
-            selfReference = null;
+            catch (JSDisconnectedException)
+            {
+                // The circuit is already gone, so there is nothing left to clean up on the JS side.
+            }
+            catch (JSException)
+            {
+                // A failing teardown on the JS side must not stop the managed references from being released.
+            }
+            finally
+            {
+                _module = null;
+                selfReference?.Dispose();
+                selfReference = null;
+            }
         }
 
         [JSInvokable]
@@ -170,9 +190,10 @@ namespace BlazorSortableList
                 _module = await JS.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorSortableList/SortableList.razor.js");
 
                 //await JS.InvokeVoidAsync("console.log", $"***id:{Id}, group:{Group},pull: {Pull},put:{Put},sort:{Sort}, handle:{Handle}, filter:{Filter}, forceFallback:{ForceFallback}");
-                await _module.InvokeAsync<string>(
+                _initializedId = Id;
+                await _module.InvokeVoidAsync(
                     "init",
-                    Id,
+                    _initializedId,
                     Group,
                     Pull,
                     Put,

--- a/BlazorSortableList.Lib/SortableList.razor.cs
+++ b/BlazorSortableList.Lib/SortableList.razor.cs
@@ -13,6 +13,8 @@ namespace BlazorSortableList
 
         private DotNetObjectReference<SortableList<T>>? selfReference;
 
+        private IJSObjectReference? _module;
+
         private string _cssForSelection;
 
         private string? _multiDragKey = string.Empty;
@@ -68,7 +70,26 @@ namespace BlazorSortableList
         [Parameter]
         public RenderFragment<T>? SortableItemTemplate { get; set; }
 
-        public void Dispose() => selfReference?.Dispose();
+        public async ValueTask DisposeAsync()
+        {
+            if (_module != null)
+            {
+                try
+                {
+                    await _module.InvokeVoidAsync("destroy", Id);
+                    await _module.DisposeAsync();
+                }
+                catch (JSDisconnectedException)
+                {
+                    // The circuit is already gone, so there is nothing left to clean up on the JS side.
+                }
+
+                _module = null;
+            }
+
+            selfReference?.Dispose();
+            selfReference = null;
+        }
 
         [JSInvokable]
         public void OnDeselectJS(string fromId, int index)
@@ -146,10 +167,10 @@ namespace BlazorSortableList
             if (firstRender)
             {
                 selfReference = DotNetObjectReference.Create(this);
-                var module = await JS.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorSortableList/SortableList.razor.js");
+                _module = await JS.InvokeAsync<IJSObjectReference>("import", "./_content/BlazorSortableList/SortableList.razor.js");
 
                 //await JS.InvokeVoidAsync("console.log", $"***id:{Id}, group:{Group},pull: {Pull},put:{Put},sort:{Sort}, handle:{Handle}, filter:{Filter}, forceFallback:{ForceFallback}");
-                await module.InvokeAsync<string>(
+                await _module.InvokeAsync<string>(
                     "init",
                     Id,
                     Group,

--- a/BlazorSortableList.Lib/SortableList.razor.js
+++ b/BlazorSortableList.Lib/SortableList.razor.js
@@ -1,3 +1,13 @@
+const instances = new Map();
+
+export function destroy(id) {
+    const sortable = instances.get(id);
+    if (sortable) {
+        sortable.destroy();
+        instances.delete(id);
+    }
+}
+
 export function init(id, group, pull, put, sort, handle, filter, component, forceFallback, cssForSelection, multiDragKey, avoidImplicitDeselect, fallbackOnBody, swapThreshold) {
 
     const DEBUG_MODE = true;
@@ -50,6 +60,9 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
     //            console.log(index);
     //        }
     //    });
+
+    // A component re-initialising under an id we already track would otherwise orphan the previous instance.
+    destroy(id);
 
     var sortable = new SortableCtor(htmlElement, {
         animation: 200,
@@ -187,4 +200,6 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
             }
         }
     });
+
+    instances.set(id, sortable);
 }


### PR DESCRIPTION
### Problem

`SortableList` never releases anything it allocates:

- The class declares `public void Dispose()`, but it does not implement `IDisposable` and the `.razor` has no `@implements`, so the method is dead code and is never invoked.
- The `Sortable` instance created in `init()` is stored in a function-local `var` and never returned or registered, so nothing can reach it to call `.destroy()`.
- The imported `IJSObjectReference` module is a local in `OnAfterRenderAsync` and is likewise never disposed.

Every mount/unmount cycle (a list inside a dialog or popup, a route change) leaves behind a live Sortable instance with document-level listeners plus a leaked `DotNetObjectReference`.

### Implementation

- JS: track instances in a module-level `Map` keyed by element id and add a `destroy(id)` export. `init` now destroys a pre-existing instance under the same id before creating a new one.
- C#: keep the module in a `_module` field, implement `IAsyncDisposable`, and on disposal call `destroy`, dispose the module, and dispose `selfReference`. `JSDisconnectedException` is swallowed, since a torn-down circuit has nothing left to clean up.
- `SortableList.razor` gains `@implements IAsyncDisposable` so Blazor actually calls it.

`Dispose()` is replaced by `DisposeAsync()`. Since the old method was unreachable (the type never implemented `IDisposable`), no working call site can exist.

Builds clean; the two remaining CS8618 warnings are pre-existing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sortable list cleanup when components are removed or reinitialized.
  * Prevented obsolete sorting instances from remaining active after reinitialization.
  * Added safer handling during asynchronous cleanup when the connection is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->