### PR TITLE
Enable multiDrag only when a selection class is configured

### DIFF
--- a/BlazorSortableList.Lib/SortableList.razor.js
+++ b/BlazorSortableList.Lib/SortableList.razor.js
@@ -4,7 +4,8 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
     if (DEBUG_MODE) {
         console.log("Init for Id:", id, "swapThreshold:", swapThreshold);
     }
-    let multiDrag = (typeof cssForSelection !== 'undefined');
+    // .NET marshals an unset string as null, never undefined, so a `typeof` check here would always pass.
+    let multiDrag = !!cssForSelection;
 
     let htmlElement = document.getElementById(id);
     if (!htmlElement) {
@@ -65,7 +66,7 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
         handle: handle || undefined,
 
         multiDrag: multiDrag,
-        selectedClass: cssForSelection,
+        selectedClass: cssForSelection || undefined,
         multiDragKey: multiDragKey,
         avoidImplicitDeselect: avoidImplicitDeselect,
         swapThreshold: swapThreshold, //0.65,
@@ -78,7 +79,8 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
             let oldIndex = event.oldDraggableIndex;
             let newIndex = event.newDraggableIndex;
             // in multi selection mode we have newIndicies only
-            let newIndicies = Array.from(event.newIndicies);
+            // Only the MultiDrag plugin adds these, so they are undefined when multiDrag is off.
+            let newIndicies = event.newIndicies ? Array.from(event.newIndicies) : [];
             if (newIndicies.length > 0) {
                 newIndex = newIndicies[0].index;
 
@@ -124,7 +126,8 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
             let newIndex = event.newDraggableIndex;
 
             // in multi selection mode we have newIndicies only
-            let newIndicies = Array.from(event.newIndicies);
+            // Only the MultiDrag plugin adds these, so they are undefined when multiDrag is off.
+            let newIndicies = event.newIndicies ? Array.from(event.newIndicies) : [];
             if (newIndicies.length > 0) {
                 newIndex = newIndicies[0].index;
 


### PR DESCRIPTION
### Problem

```js
let multiDrag = (typeof cssForSelection !== 'undefined');
```

`_cssForSelection` is an uninitialised `string` field and is only assigned when `settings.MultiSelection` is set. .NET marshals an unset string as JSON `null`, never `undefined`, and `typeof null === 'object'` — so this expression is **always true**. Every list is constructed with `multiDrag: true` and `selectedClass: null`, whether or not multi-selection was requested.

The `Array.from(event.newIndicies)` calls in `onUpdate`/`onRemove` currently only survive because of this: `oldIndicies`/`newIndicies` are added exclusively by the MultiDrag plugin's `eventProperties()`, so with multiDrag correctly off they are `undefined` and `Array.from` would throw.

### Implementation

- `multiDrag` is now a truthiness check on `cssForSelection`, so `null` and `''` both correctly disable it.
- `selectedClass` passes `undefined` instead of `null` when unset, so SortableJS applies its own default rather than a null class.
- `newIndicies` is guarded in both `onUpdate` and `onRemove`, falling back to `[]` — required now that multiDrag can actually be off.