### PR TITLE
Interpolate the OnUpdate/DefaultSort conflict message

### DIFF
--- a/BlazorSortableList.Lib/SortableList.razor.cs
+++ b/BlazorSortableList.Lib/SortableList.razor.cs
@@ -127,8 +127,8 @@ namespace BlazorSortableList
                 {
                     if (DefaultSort)
                     {
-                        throw new ArgumentException(
-                            "It must be defined as either {nameof(OnUpdate)} or {nameof(DefaultSort)}, but not both together.");
+                        throw new InvalidOperationException(
+                            $"It must be defined as either {nameof(OnUpdate)} or {nameof(DefaultSort)}, but not both together.");
                     }
 
                     // invoke the OnUpdate event passing in the oldIndex and the newIndex


### PR DESCRIPTION
### Problem

The guard against setting both `OnUpdate` and `DefaultSort` builds its message without the `$` prefix:

```csharp
throw new ArgumentException(
    "It must be defined as either {nameof(OnUpdate)} or {nameof(DefaultSort)}, but not both together.");
```

The braces are emitted literally, so the developer sees `{nameof(OnUpdate)}` rather than `OnUpdate`.

### Implementation

Added the missing `$`, and switched to `InvalidOperationException` — the fault is a conflicting component configuration, not a bad method argument.