### PR TITLE
Restore drag position against children, not childNodes

### DIFF
--- a/BlazorSortableList.Lib/SortableList.razor.js
+++ b/BlazorSortableList.Lib/SortableList.razor.js
@@ -93,7 +93,7 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
 
                 let oldIndicies = Array.from(event.oldIndicies);
                 oldIndicies.forEach((item) => {
-                    event.to.insertBefore(item.multiDragElement, event.to.childNodes[item.index]);
+                    event.to.insertBefore(item.multiDragElement, event.to.children[item.index]);
                 });
             } else {
                 if (DEBUG_MODE) {
@@ -105,7 +105,7 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
 
                 // method inserts a child node before an existing child. insertBefore(newNode, referenceNode)
                 // referenceNode - The node before which newNode is inserted
-                event.to.insertBefore(event.item, event.to.childNodes[event.oldIndex]);
+                event.to.insertBefore(event.item, event.to.children[event.oldIndex]);
             }
             // Notify .NET to update its model and re-render
             component.invokeMethodAsync('OnUpdateJS', oldIndex, newIndex, event.from.id);
@@ -138,12 +138,12 @@ export function init(id, group, pull, put, sort, handle, filter, component, forc
 
                 let oldIndicies = Array.from(event.oldIndicies);
                 oldIndicies.forEach((item) => {
-                    event.from.insertBefore(item.multiDragElement, event.from.childNodes[item.index]);
+                    event.from.insertBefore(item.multiDragElement, event.from.children[item.index]);
                 });
             } else {
                 // Revert the DOM to match the .NET state
                 event.item.remove();
-                event.from.insertBefore(event.item, event.from.childNodes[event.oldIndex]);
+                event.from.insertBefore(event.item, event.from.children[event.oldIndex]);
             }
 
             // Notify .NET to update its model and re-render


### PR DESCRIPTION
### Problem

The DOM-revert logic in `onUpdate`/`onRemove` resolves the reference node through `childNodes`:

```js
event.to.insertBefore(event.item, event.to.childNodes[event.oldIndex]);
```

`childNodes` is a `NodeList` that includes text and comment nodes, while the indices SortableJS reports count elements only. Any whitespace text node or comment between items — both of which a Blazor render tree can emit around the item template — shifts the reference node and the item is reinserted at the wrong position, leaving the DOM out of step with the .NET model.

`onSelect`/`onDeselect` in the same file already use `.children` for exactly this reason, so the two index spaces were mixed within one module.

### Implementation

Replaced all four `childNodes` lookups with `children` (an `HTMLCollection` of elements only). Where no non-element nodes exist the two are equivalent, so this is a no-op in the working case and a fix in the rest.

Index semantics are otherwise untouched — the existing `oldIndex` vs `oldDraggableIndex` split is left as-is.