### PR TITLE
Document that SortableItemTemplate roots need a @key

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -109,7 +109,7 @@ The `SortableItemTemplate` can contain any markup or components that you want. `
 
 ### Put a `@key` on the root of your item template
 
-After a drag, the JS interop layer moves the dragged node back to its original position so that the DOM matches the .NET model again, and the model change then triggers a normal Blazor re-render. That is a DOM mutation Blazor's renderer did not perform itself, so without a key its diff matches the reused elements up positionally and can associate the wrong element with the wrong item - typically showing up as stale text, a lost input value, or focus jumping to a neighbouring row.
+After a drag, the JS interop layer moves the dragged node back to its original position so that the DOM matches the .NET model again, and the model change then triggers a normal Blazor re-render. That is a DOM mutation Blazor's renderer did not perform itself, so without a key its diff pairs up the reused elements by position and can associate the wrong element with the wrong item - typically showing up as stale text, a lost input value, or focus jumping to a neighbouring row.
 
 Give the outermost element or component inside `SortableItemTemplate` a [`@key`](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering#the-key-directive-attribute) bound to something stable per item:
 

--- a/README.MD
+++ b/README.MD
@@ -107,6 +107,24 @@ protected override async Task OnInitializedAsync()
 
 The `SortableItemTemplate` can contain any markup or components that you want. `SortList` implementation see below.
 
+### Put a `@key` on the root of your item template
+
+After a drag, the JS interop layer moves the dragged node back to its original position so that the DOM matches the .NET model again, and the model change then triggers a normal Blazor re-render. That is a DOM mutation Blazor's renderer did not perform itself, so without a key its diff matches the reused elements up positionally and can associate the wrong element with the wrong item - typically showing up as stale text, a lost input value, or focus jumping to a neighbouring row.
+
+Give the outermost element or component inside `SortableItemTemplate` a [`@key`](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering#the-key-directive-attribute) bound to something stable per item:
+
+```html
+<SortableList Id="sortable" Items="items" OnUpdate="@SortList" Context="item">
+    <SortableItemTemplate>
+        <div @key="item.Id">
+            <p>@item.Name</p>
+        </div>
+    </SortableItemTemplate>
+</SortableList>
+```
+
+The component cannot apply the key on your behalf: `@key` is a directive attribute that has to sit on an element or component frame, and `SortableList` only ever invokes the template as an opaque `RenderFragment<T>`. Keying it internally would mean wrapping every item in an extra element, which would change the markup and CSS of existing consumers.
+
 ## Attributes
 
 ### Properties


### PR DESCRIPTION
### Problem

`SortableList` renders its items with a plain unkeyed loop:

```razor
@foreach (var item in Items)
{
    @SortableItemTemplate(item)
}
```

The interop layer deliberately moves the dragged node back to its original DOM position before notifying .NET, so by the time the re-render runs Blazor is diffing against a tree it did not mutate itself. Without keys the diff matches reused elements positionally, which can associate the wrong element with the wrong item — stale text, a lost input value, or focus landing on a neighbouring row.

### Implementation

This is a docs change rather than a code fix, because the library cannot key the items itself: `@key` is a directive attribute that must sit on an element or component frame, and `SortableList` only invokes the template as an opaque `RenderFragment<T>`. Adding a key internally would require wrapping every item in an extra element, changing the markup and CSS of every existing consumer.

So the README now states the requirement explicitly, with an example and the reason it cannot be handled inside the component.

Happy to switch this to a keyed wrapper element behind an opt-in parameter instead if you would prefer a code-level fix.